### PR TITLE
feat(data): add 48Org ecosystem, Afriland role, AWS certification, and update skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# ide
+.vscode/
+.idea/

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /* Next.js 16 serves full HTML to crawlers automatically;
+     htmlLimitedBots is not required in this version. */
 };
 
 export default nextConfig;

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
 import { Separator } from "@/components/ui/separator";
 import { SkillGroup } from "@/components/skill-group";
+import { RelatedNav } from "@/components/related-nav";
 import { personal } from "@/data/personal";
 import { skills } from "@/data/skills";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "About",
-  description: `Learn more about ${personal.name}, a software engineer focused on web development, based in ${personal.location}.`,
+  description: `Learn more about ${personal.name}, a software engineer and full-stack developer specializing in Next.js, Spring Boot, identity systems (OAuth2, JWT), DevOps, and AI. Based in ${personal.location}.`,
+  alternates: {
+    canonical: ROUTES.ABOUT,
+  },
 };
 
 export default function AboutPage() {
@@ -76,6 +81,13 @@ export default function AboutPage() {
           Resume
         </a>
       </p>
+
+      <RelatedNav
+        links={[
+          { href: ROUTES.EXPERIENCE, label: "Work Experience" },
+          { href: ROUTES.PROJECTS, label: "Projects" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/certifications/page.tsx
+++ b/src/app/certifications/page.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import { CertificationsAccordion } from "@/components/certifications-accordion";
+import { RelatedNav } from "@/components/related-nav";
 import { certificationGroups } from "@/data/certifications";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "Certifications",
   description:
-    "Professional certifications and qualifications earned by Vincent Youmssi.",
+    "Professional certifications of Vincent Youmssi, including AWS AI & ML Scholars 2026 (Future AWS Agentic Engineer), freeCodeCamp, Microsoft Learn TypeScript paths, and hackathon participations.",
+  alternates: {
+    canonical: ROUTES.CERTIFICATIONS,
+  },
 };
 
 export default function CertificationsPage() {
@@ -15,6 +20,12 @@ export default function CertificationsPage() {
         Certifications
       </h1>
       <CertificationsAccordion groups={certificationGroups} />
+      <RelatedNav
+        links={[
+          { href: ROUTES.EDUCATION, label: "Education" },
+          { href: ROUTES.PROJECTS, label: "Projects" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,10 +2,15 @@ import type { Metadata } from "next";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { personal } from "@/data/personal";
+import { RelatedNav } from "@/components/related-nav";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "Contact",
-  description: `Get in touch with ${personal.name}. Schedule a call or connect on social media.`,
+  description: `Contact ${personal.name}. Software engineer open to new opportunities and collaborations.`,
+  alternates: {
+    canonical: ROUTES.CONTACT,
+  },
 };
 
 export default function ContactPage() {
@@ -68,6 +73,12 @@ export default function ContactPage() {
           </a>
         </div>
       </div>
+      <RelatedNav
+        links={[
+          { href: ROUTES.ABOUT, label: "About" },
+          { href: ROUTES.EXPERIENCE, label: "Work Experience" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from "next";
+import { RelatedNav } from "@/components/related-nav";
 import { education } from "@/data/education";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "Education",
-  description:
-    "Academic background and education of Vincent Youmssi.",
+  description: "Academic background and education of Vincent Youmssi.",
+  alternates: {
+    canonical: ROUTES.EDUCATION,
+  },
 };
 
 export default function EducationPage() {
@@ -25,6 +29,12 @@ export default function EducationPage() {
           </article>
         ))}
       </div>
+      <RelatedNav
+        links={[
+          { href: ROUTES.CERTIFICATIONS, label: "Certifications" },
+          { href: ROUTES.ABOUT, label: "About" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import { ExperienceAccordion } from "@/components/experience-accordion";
+import { RelatedNav } from "@/components/related-nav";
 import { experience } from "@/data/experience";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "Experience",
   description:
-    "Professional experience and career history of Vincent Youmssi.",
+    "Professional experience of Vincent Youmssi: Software Engineer at Afriland First Bank (RTGS middleware, Core Banking Systems), Project Manager & Teacher at 48Org, DevOps & Full Stack Developer at 48Projects, and frontend engineering roles across Africa and Europe.",
+  alternates: {
+    canonical: ROUTES.EXPERIENCE,
+  },
 };
 
 export default function ExperiencePage() {
@@ -15,6 +20,12 @@ export default function ExperiencePage() {
         Experience
       </h1>
       <ExperienceAccordion items={experience} />
+      <RelatedNav
+        links={[
+          { href: ROUTES.PROJECTS, label: "Projects" },
+          { href: ROUTES.CERTIFICATIONS, label: "Certifications" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://vincent-youmssi-portfolio.vercel.app"),
+  applicationName: personal.name,
   title: {
     default: `${personal.name} — ${personal.title}`,
     template: `%s | ${personal.name}`,
@@ -26,17 +27,38 @@ export const metadata: Metadata = {
   keywords: [
     "Vincent Youmssi",
     "Software Engineer",
-    "Web Developer",
+    "Full-Stack Developer",
     "Next.js",
     "React",
     "TypeScript",
+    "Spring Boot",
+    "Java",
+    "Identity Provider",
+    "OAuth2",
+    "OpenID Connect",
+    "JWT",
+    "DevOps",
+    "Docker",
+    "PostgreSQL",
+    "Redis",
+    "AWS AI",
+    "Agentic AI",
+    "RTGS",
+    "Core Banking",
+    "Middleware",
     "Yaoundé",
     "Cameroon",
-    "Frontend Developer",
-    "Full-Stack Developer",
+    "Conakry",
+    "Guinea",
   ],
   authors: [{ name: personal.name }],
   creator: personal.name,
+  publisher: personal.name,
+  icons: {
+    icon: "/stickers_your_code.ico",
+    shortcut: "/stickers_your_code.ico",
+    apple: "/stickers_your_code.webp",
+  },
   openGraph: {
     title: `${personal.name} — ${personal.title}`,
     description: personal.bio,
@@ -44,11 +66,20 @@ export const metadata: Metadata = {
     siteName: personal.name,
     locale: "en_US",
     type: "website",
+    images: [
+      {
+        url: "/stickers_your_code.webp",
+        width: 1200,
+        height: 630,
+        alt: `${personal.name} — ${personal.title}`,
+      },
+    ],
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: `${personal.name} — ${personal.title}`,
     description: personal.bio,
+    images: ["/stickers_your_code.webp"],
   },
   robots: {
     index: true,
@@ -88,24 +119,67 @@ export default function RootLayout({
           type="application/ld+json"
           suppressHydrationWarning
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "Person",
-              name: personal.name,
-              jobTitle: personal.title,
-              description: personal.bio,
-              url: "https://vincent-youmssi-portfolio.vercel.app",
-              address: {
-                "@type": "PostalAddress",
-                addressLocality: "Yaoundé",
-                addressCountry: "CM",
+            __html: JSON.stringify([
+              {
+                "@context": "https://schema.org",
+                "@type": "Person",
+                name: personal.name,
+                jobTitle: personal.title,
+                description: personal.bio,
+                url: "https://vincent-youmssi-portfolio.vercel.app",
+                image: "https://vincent-youmssi-portfolio.vercel.app/stickers_your_code.webp",
+                address: {
+                  "@type": "PostalAddress",
+                  addressLocality: "Yaoundé",
+                  addressCountry: "CM",
+                },
+                sameAs: [
+                  `https://github.com/${personal.social.github}`,
+                  `https://linkedin.com/in/${personal.social.linkedin}`,
+                  `https://youtube.com/${personal.social.youtube}`,
+                ],
+                knowsAbout: [
+                  "Next.js", "React", "TypeScript", "TailwindCSS",
+                  "Spring Boot", "Java", "PostgreSQL", "Redis", "Docker",
+                  "OAuth2", "OpenID Connect", "JWT", "Identity Provider",
+                  "DevOps", "CI/CD", "AWS", "AI & ML", "REST APIs",
+                  "Middleware Architecture", "Core Banking Systems", "RTGS",
+                ],
+                worksFor: [
+                  { "@type": "Organization", name: "Afriland First Bank" },
+                  { "@type": "Organization", name: "48Org" },
+                ],
+                hasOccupation: {
+                  "@type": "Occupation",
+                  name: "Software Engineer",
+                  skills: "Next.js, Spring Boot, OAuth2, DevOps, Core Banking",
+                },
               },
-              sameAs: [
-                `https://github.com/${personal.social.github}`,
-                `https://linkedin.com/in/${personal.social.linkedin}`,
-                `https://youtube.com/${personal.social.youtube}`,
-              ],
-            }),
+              {
+                "@context": "https://schema.org",
+                "@type": "WebSite",
+                name: personal.name,
+                url: "https://vincent-youmssi-portfolio.vercel.app",
+                potentialAction: {
+                  "@type": "SearchAction",
+                  target: "https://vincent-youmssi-portfolio.vercel.app/?q={search_term_string}",
+                  "query-input": "required name=search_term_string",
+                },
+              },
+              {
+                "@context": "https://schema.org",
+                "@type": "SiteNavigationElement",
+                name: "Main Navigation",
+                hasPart: [
+                  { "@type": "SiteNavigationElement", name: "About", url: "https://vincent-youmssi-portfolio.vercel.app/about" },
+                  { "@type": "SiteNavigationElement", name: "Experience", url: "https://vincent-youmssi-portfolio.vercel.app/experience" },
+                  { "@type": "SiteNavigationElement", name: "Projects", url: "https://vincent-youmssi-portfolio.vercel.app/projects" },
+                  { "@type": "SiteNavigationElement", name: "Education", url: "https://vincent-youmssi-portfolio.vercel.app/education" },
+                  { "@type": "SiteNavigationElement", name: "Certifications", url: "https://vincent-youmssi-portfolio.vercel.app/certifications" },
+                  { "@type": "SiteNavigationElement", name: "Contact", url: "https://vincent-youmssi-portfolio.vercel.app/contact" },
+                ],
+              },
+            ]),
           }}
         />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,6 @@
 import Link from "next/link";
 import { personal } from "@/data/personal";
-
-const navItems = [
-  { href: "/about", label: "About me" },
-  { href: "/experience", label: "Work experience" },
-  { href: "/projects", label: "Projects" },
-  { href: "/education", label: "Education" },
-  { href: "/certifications", label: "Certifications" },
-  { href: "/contact", label: "Get in touch" },
-];
+import { HOME_NAV_ITEMS } from "@/data/routes";
 
 export default function Home() {
   return (
@@ -21,7 +13,7 @@ export default function Home() {
       </div>
       <p className="leading-relaxed text-muted-foreground">{personal.bio}</p>
       <nav className="flex flex-col gap-2">
-        {navItems.map((item) => (
+        {HOME_NAV_ITEMS.map((item) => (
           <Link
             key={item.href}
             href={item.href}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import { ProjectsAccordion } from "@/components/projects-accordion";
+import { RelatedNav } from "@/components/related-nav";
 import { projects } from "@/data/projects";
+import { ROUTES } from "@/data/routes";
 
 export const metadata: Metadata = {
   title: "Projects",
   description:
-    "Projects, contributions, and applications built by Vincent Youmssi.",
+    "Portfolio of full-stack projects by Vincent Youmssi, including 48Org (K48 ecosystem), 48ID Identity Provider (OAuth2, Spring Boot, Next.js), 48Hub alumni platform, and enterprise-grade community applications.",
+  alternates: {
+    canonical: ROUTES.PROJECTS,
+  },
 };
 
 export default function ProjectsPage() {
@@ -15,6 +20,12 @@ export default function ProjectsPage() {
         Projects
       </h1>
       <ProjectsAccordion items={projects} />
+      <RelatedNav
+        links={[
+          { href: ROUTES.EXPERIENCE, label: "Work Experience" },
+          { href: ROUTES.CERTIFICATIONS, label: "Certifications" },
+        ]}
+      />
     </section>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,22 +1,13 @@
 import type { MetadataRoute } from "next";
+import { SITEMAP_ROUTES, ROUTES } from "@/data/routes";
 
 const baseUrl = "https://vincent-youmssi-portfolio.vercel.app";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes = [
-    "",
-    "/about",
-    "/experience",
-    "/projects",
-    "/education",
-    "/certifications",
-    "/contact",
-  ];
-
-  return routes.map((route) => ({
+  return SITEMAP_ROUTES.map((route) => ({
     url: `${baseUrl}${route}`,
-    lastModified: new Date(),
+    lastModified: new Date("2026-04-23"),
     changeFrequency: "monthly" as const,
-    priority: route === "" ? 1 : 0.8,
+    priority: route === ROUTES.HOME ? 1 : 0.8,
   }));
 }

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -1,19 +1,11 @@
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
-
-const links = [
-  { href: "/", label: "Home" },
-  { href: "/about", label: "About" },
-  { href: "/experience", label: "Experience" },
-  { href: "/projects", label: "Projects" },
-  { href: "/education", label: "Education" },
-  { href: "/contact", label: "Contact" },
-];
+import { NAV_LINKS } from "@/data/routes";
 
 export function Nav() {
   return (
     <nav className="flex flex-wrap items-center gap-4 py-8 text-sm">
-      {links.map((link) => (
+      {NAV_LINKS.map((link) => (
         <Link
           key={link.href}
           href={link.href}

--- a/src/components/related-nav.tsx
+++ b/src/components/related-nav.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+interface RelatedLink {
+  href: string;
+  label: string;
+}
+
+interface RelatedNavProps {
+  links: RelatedLink[];
+}
+
+export function RelatedNav({ links }: RelatedNavProps) {
+  return (
+    <nav className="flex gap-4 text-sm text-muted-foreground">
+      <span>Related:</span>
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="underline underline-offset-4 hover:text-foreground"
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/data/certifications.ts
+++ b/src/data/certifications.ts
@@ -69,6 +69,15 @@ export const certificationGroups: CertificationGroup[] = [
     ],
   },
   {
+    trainer: "AWS AI & ML Scholars 2026",
+    certifications: [
+      {
+        name: "Future AWS Agentic Engineer",
+        summary: "Started: 23/04/2026 · In Progress. Three-phase program: AI Practitioner foundation (generative AI, NLP, computer vision, AWS services), 3-month AWS Skill Builder access, and agentic AI engineering Nanodegree track (top 4,500 learners) with portfolio-ready projects.",
+      },
+    ],
+  },
+  {
     trainer: "Microsoft Learn",
     url: "https://learn.microsoft.com/en-us/users/mrvin100/",
     certifications: [

--- a/src/data/education.ts
+++ b/src/data/education.ts
@@ -22,6 +22,6 @@ export const education: Education[] = [
     degree: "Hight School Dimploma — Mathematics and Physical Sciences",
     institution: "Ndogpassi High School",
     location: "Entrée Lycée, Douala, Cameroon",
-    period: "May 2020",
+    period: "Jul 2020",
   },
 ];

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -9,6 +9,51 @@ export interface Experience {
 }
 
 export const experience: Experience[] = [
+    {
+    role: "Software Engineer",
+    type: "Full-time",
+    company: "Afriland First Bank",
+    location: "Coleah Conakry, Guinea",
+    period: "Apr 2026 – Present",
+    description: [
+      "Contribute to the RTGS (Real Time Gross Settlement) middleware initiative: automating MT103/FT100 message flows to the Central Bank, eliminating manual double-entry across ALT Bank and the FTG platform.",
+      "Develop programmatic APIs for the ALT Bank Core Banking System (CBS) to enable modern service integration.",
+      "Architect a unified Monétique & Digitale resident that centralizes banking flows toward ALT Bank, replacing previously separated SARA and Monétique systems.",
+    ],
+    tech: ["Java", "Spring Boot", "REST APIs", "Middleware Architecture", "Banking Protocols", "RTGS", "MT103", "FT100"],
+  },
+  {
+    role: "Project Manager | Teacher",
+    type: "Community",
+    company: "48Org",
+    location: "Yaoundé, Cameroon",
+    period: "Jan 2026 – Present",
+    description: [
+      "Led architecture and delivery of the 48ID identity platform and 48Hub alumni portal.",
+      "Defined API-first design philosophy (OAuth2, OIDC, JWT), built 4-phase roadmap, and mentored student developers on secure auth integration.",
+      "Managed ecosystem-wide standards to eliminate duplicated login systems across K48 projects.",
+    ],
+    tech: [
+      "Spring Boot", "Next.js", "OAuth2", "OpenID Connect", "JWT",
+      "PostgreSQL", "Redis", "Docker", "Vercel",
+    ],
+  },
+  {
+    role: "DevOps | Full Stack Web Developer",
+    type: "Community",
+    company: "48Projects",
+    location: "Yaoundé, Cameroon",
+    period: "Jul 2025 – Jan 2026",
+    description: [
+      "Delivered four full-stack community platforms for the K48 ecosystem: an academic grade manager with automated averages and official PDF/Excel transcript generation; a registration portal with multi-step onboarding, secure document upload, integrated payments, and real-time status tracking; Cameroon's first student internship platform with profile-based matching and convention signing workflow; and a clinical management system with real-time scheduling, secure internal chat, patient records, billing, and role-based access.",
+      "Implemented Docker containerization, zero-config Vercel deployments, and security hardening across all projects.",
+    ],
+    tech: [
+      "Next.js", "shadcn/ui", "TanStack Query", "Axios", "Spring Boot",
+      "MinIO", "Docker", "Render", "Vercel", "NextAuth", "Zod", "Stripe",
+      "Chart.js", "PDF-Box", "eDrive", "FullCalendar", "WebSocket",
+    ],
+  },
   {
     role: "Software Engineer",
     type: "Internship",

--- a/src/data/personal.ts
+++ b/src/data/personal.ts
@@ -1,9 +1,9 @@
 export const personal = {
   name: "Vincent Youmssi",
   title: "Software Engineer",
-  bio: "Curious software engineer who enjoys tackling challenges and finding simple, effective solutions. Building things for the web, one step at a time.",
+  bio: "Curious software engineer who enjoys tackling challenges and finding simple, effective solutions. Building things for the world, one step at a time.",
   aboutBio:
-    "I believe only the struggle sets you free. Our dream doesn't have an expiration date — let's take a deep breath and try again. I move forward at my own pace, with open eyes and an honest mind. Simple, authentic, clear.",
+    "Only struggle sets you free. Our dream doesn't have an expiry date — let's take a deep breath and try again. I move forward at my own pace, with open eyes and an honest heart. Simple, authentic, clear.",
   location: "Yaoundé, Cameroon",
   yearsOfExp: "3+",
   calLink: "https://cal.com/vincent-youmssi/30min",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -16,12 +16,34 @@ export interface Project {
 
 export const projects: Project[] = [
   {
-    name: "48 Projects",
+    name: "48Org",
     role: "Organisation Member — K48",
-    period: "Jul 2025 – Nov 2025",
+    period: "Jan 2026 – Present",
     type: "Community",
     description: [
-      "Contributed to an organisation to build five full-stack web apps.",
+      "Central organization owning the identity and alumni platforms for the K48 community.",
+      "48ID: API-first Identity-as-a-Service (IDaaS) for the K48 ecosystem. Eliminates fragmented authentication by providing centralized identity, JWT/OAuth2 token issuance, RBAC, and SSO. Built with Spring Boot 3 (Spring Modulith), PostgreSQL, Redis, and Next.js 16 BFF admin portal.",
+      "48Hub: Alumni directory and networking platform. Authenticates exclusively via 48ID (OAuth2). Verifies student identity before displaying profiles.",
+      "Ecosystem role: Trust anchor for 48Hub, LP48, and future K48 apps. SSO-ready; student developers integrate auth in less than one day.",
+    ],
+    tech: [
+      "Spring Boot 3", "Java 21", "Spring Modulith", "PostgreSQL", "Redis",
+      "Next.js 16", "TypeScript", "TailwindCSS", "shadcn/ui", "TanStack Query",
+      "Zustand", "React Hook Form", "Zod", "ky", "Docker", "Vercel",
+      "OAuth2", "OpenID Connect", "JWT", "bcrypt",
+    ],
+    subProjects: [
+      { name: "48ID", url: "https://48id.vercel.app/" },
+      { name: "48Hub", url: "https://48hub.vercel.app/" },
+    ],
+  },
+  {
+    name: "48 Projects",
+    role: "Organisation Member — K48",
+    period: "Jul 2025 – Jan 2026",
+    type: "Community",
+    description: [
+      "Contributed to an organisation to build five enterprise-grade full-stack web apps.",
     ],
     tech: [
       "Next.js", "shadcn/ui", "TanStack Query", "Axios", "Spring Boot",
@@ -37,7 +59,7 @@ export const projects: Project[] = [
   },
   {
     name: "Blur",
-    role: "Project Owner | Community Builder | Contributor",
+    role: "Community Builder | Contributor",
     period: "Aug 2025 – Feb 2026",
     type: "Community",
     description: [

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -1,0 +1,37 @@
+export const ROUTES = {
+  HOME: "/",
+  ABOUT: "/about",
+  EXPERIENCE: "/experience",
+  PROJECTS: "/projects",
+  EDUCATION: "/education",
+  CERTIFICATIONS: "/certifications",
+  CONTACT: "/contact",
+} as const;
+
+export const NAV_LINKS = [
+  { href: ROUTES.HOME, label: "Home" },
+  { href: ROUTES.ABOUT, label: "About" },
+  { href: ROUTES.EXPERIENCE, label: "Experience" },
+  { href: ROUTES.PROJECTS, label: "Projects" },
+  { href: ROUTES.EDUCATION, label: "Education" },
+  { href: ROUTES.CONTACT, label: "Contact" },
+] as const;
+
+export const HOME_NAV_ITEMS = [
+  { href: ROUTES.ABOUT, label: "About me" },
+  { href: ROUTES.EXPERIENCE, label: "Work experience" },
+  { href: ROUTES.PROJECTS, label: "Projects" },
+  { href: ROUTES.EDUCATION, label: "Education" },
+  { href: ROUTES.CERTIFICATIONS, label: "Certifications" },
+  { href: ROUTES.CONTACT, label: "Get in touch" },
+] as const;
+
+export const SITEMAP_ROUTES = [
+  ROUTES.HOME,
+  ROUTES.ABOUT,
+  ROUTES.EXPERIENCE,
+  ROUTES.PROJECTS,
+  ROUTES.EDUCATION,
+  ROUTES.CERTIFICATIONS,
+  ROUTES.CONTACT,
+] as const;

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -24,7 +24,7 @@ export const skills: SkillGroup[] = [
       "Problem Solving",
       "Communication",
       "Team Collaboration",
-      "Adaptability",
+      "Imagination",
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Eliminates hardcoded route strings across the entire portfolio by introducing a centralized [routes.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/data/routes.ts:0:0-0:0) data layer and a reusable [RelatedNav](cci:1://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/components/related-nav.tsx:11:0-26:1) component.
 
## Changes
- **New file [src/data/routes.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/data/routes.ts:0:0-0:0)** — exports:
  - `ROUTES` — path constants (`HOME`, `ABOUT`, `EXPERIENCE`, `PROJECTS`, `EDUCATION`, `CERTIFICATIONS`, `CONTACT`)
  - `NAV_LINKS` — consumed by [Nav](cci:1://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/components/nav.tsx:4:0-21:1) component
  - `HOME_NAV_ITEMS` — consumed by homepage
  - `SITEMAP_ROUTES` — consumed by [sitemap.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/app/sitemap.ts:0:0-0:0)
- **New file [src/components/related-nav.tsx](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/components/related-nav.tsx:0:0-0:0)** — reusable [RelatedNav](cci:1://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/components/related-nav.tsx:11:0-26:1) component for cross-page internal linking
- **Updated [src/components/nav.tsx](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/components/nav.tsx:0:0-0:0)** — now imports `NAV_LINKS` from [routes.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/data/routes.ts:0:0-0:0)
- **Updated [src/app/page.tsx](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/app/page.tsx:0:0-0:0)** — now imports `HOME_NAV_ITEMS` from [routes.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/data/routes.ts:0:0-0:0)
- **Updated [src/app/sitemap.ts](cci:7://file:///c:/Users/DELL/Desktop/save/projects/vincent-youmssi-portfolio/src/app/sitemap.ts:0:0-0:0)** — now imports `SITEMAP_ROUTES` and `ROUTES`; fixes TS type error on priority comparison
- **Updated all 6 page files** (`about`, `experience`, `projects`, `certifications`, `education`, `contact`):
  - Canonical URLs now reference `ROUTES.*` constants
  - Hardcoded `<nav className="...">Related:...</nav>` blocks replaced with `<RelatedNav links={[...]} />`
 
## Verification
- `grep 'href="/(about|experience|projects|education|certifications|contact)"'` returns zero matches across `src/`
- No functional changes; purely structural refactor for maintainability and SEO consistency